### PR TITLE
Add dependency fallbacks

### DIFF
--- a/bot/utils/helpers.py
+++ b/bot/utils/helpers.py
@@ -8,7 +8,18 @@ import re
 import time
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Union
-from fuzzywuzzy import fuzz
+try:
+    from fuzzywuzzy import fuzz
+except ImportError:  # Fallback simples caso fuzzywuzzy não esteja instalado
+    from difflib import SequenceMatcher
+
+    class _FuzzWrapper:
+        @staticmethod
+        def ratio(a: str, b: str) -> float:
+            """Calcula similaridade aproximada usando difflib."""
+            return SequenceMatcher(None, a, b).ratio() * 100
+
+    fuzz = _FuzzWrapper()
 
 
 def normalize_team_name(team_name: str) -> str:

--- a/bot/utils/logger_config.py
+++ b/bot/utils/logger_config.py
@@ -11,7 +11,10 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional
 
-import colorlog
+try:
+    import colorlog
+except ImportError:  # Fallback simples quando colorlog não está disponível
+    colorlog = None
 
 
 def setup_logging(
@@ -47,24 +50,30 @@ def setup_logging(
     log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     date_format = "%Y-%m-%d %H:%M:%S"
     
-    # Handler para console com cores
-    console_handler = colorlog.StreamHandler()
-    console_handler.setLevel(numeric_level)
-    
-    # Formato colorido para console
-    color_format = "%(log_color)s%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    color_formatter = colorlog.ColoredFormatter(
-        color_format,
-        datefmt=date_format,
-        log_colors={
-            'DEBUG': 'cyan',
-            'INFO': 'green',
-            'WARNING': 'yellow',
-            'ERROR': 'red',
-            'CRITICAL': 'red,bg_white',
-        }
-    )
-    console_handler.setFormatter(color_formatter)
+    # Handler para console (usa cores se colorlog estiver disponível)
+    if colorlog:
+        console_handler = colorlog.StreamHandler()
+        console_handler.setLevel(numeric_level)
+
+        color_format = "%(log_color)s%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        color_formatter = colorlog.ColoredFormatter(
+            color_format,
+            datefmt=date_format,
+            log_colors={
+                'DEBUG': 'cyan',
+                'INFO': 'green',
+                'WARNING': 'yellow',
+                'ERROR': 'red',
+                'CRITICAL': 'red,bg_white',
+            }
+        )
+        console_handler.setFormatter(color_formatter)
+    else:
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(numeric_level)
+        formatter = logging.Formatter(log_format, datefmt=date_format)
+        console_handler.setFormatter(formatter)
+
     logger.addHandler(console_handler)
     
     # Handler para arquivo (se especificado)


### PR DESCRIPTION
## Summary
- fallback to difflib when fuzzywuzzy is missing
- gracefully handle missing colorlog dependency

## Testing
- `python -m py_compile bot/utils/helpers.py bot/utils/logger_config.py`
- `pytest tests/test_composition_analyzer.py -vv` *(fails: PytestUnhandledCoroutineWarning)*
- `pytest -q` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68438aa3edd4832c807f0c39e35eec55